### PR TITLE
feat: move scalar type from API to plugin

### DIFF
--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -1,3 +1,6 @@
+"A date"
+scalar Date
+
 extend type Mutation {
   "Generate sitemap documents"
   generateSitemaps(


### PR DESCRIPTION
When trying to install this plugin into the API, there were errors thrown indicating that we needed to move the `Date` scalar into this package, instead of having it in the API. This PR moves that scalar.

The scalar has been removed from the API [here](https://github.com/reactioncommerce/reaction/pull/6144/commits/cba85d335e96cf3fb5eb80a6e8e8f0d1bd5d59fe), and once this PR is merged, we can update the API branch with the latest release of this project and fix the issue.